### PR TITLE
Adjustment of the option for one-page layout

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -27,7 +27,7 @@
 %
 \documentclass[a4paper,
 pagebackref, % auskommentieren, falls Sie BibLaTeX benutzen
-twoside, % auskommentieren, falls Sie einseitig binden wollen
+% oneside, % auskommentieren, falls Sie einseitig binden wollen
 % Die folgende Zeile einkommentieren, falls Sie ein PDF-A benötigen
 % pdfa,pdfapart=2,pdfaconformance=A,extension=pdf
 ]{book}


### PR DESCRIPTION
Because the document uses the ``book`` class, whose default behavior is a double-page layout, the current information does not result in the desired behavior.
For single-page layout the ``oneside`` option is mandatory.

More info: [Overleaf Docs](https://www.overleaf.com/learn/latex/Single_sided_and_double_sided_documents)