### PR TITLE
Fix command \imgABCD

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -641,7 +641,7 @@
 	\def\tmpvalsev{#7}%
 	\def\tmpvaleig{#8}%
 	\def\tmpvalnin{#9}%
-	\imgABCcontinued%
+	\imgABCDcontinued%
 }%
 \newcommand{\imgABCDcontinued}[6]{%
 	\begin{figure}[htbp]%


### PR DESCRIPTION
This commit fixes the command `\imgABCD ` which was calling `\imgABCcontinued` instead of `\imgABCDcontinued`