### PR TITLE
fix: Added vertical space between chapters in the 'Quellkodeverzeichnis' (consistency)

### DIFF
--- a/frontbackmatter/tocLists.tex
+++ b/frontbackmatter/tocLists.tex
@@ -8,6 +8,16 @@
 \cleardoublepage\pdfbookmark{\contentsname}{toc}\tableofcontents\label{refTOC}
 \cleardoublepage
 
+% Füge bei neuem Kapitelbeginn in "list of listings" einen vspace von 10pt ein.
+% Dadurch entsteht im Quellcodeverzeichnis (wie auch in den anderen Verzeichnisen, wo das automatisch erzeugt wird) ein vertikaler Abstand zwischen den Kapiteln.
+\makeatletter
+\let\orig@chapter\chapter
+\renewcommand{\chapter}{%
+    \addtocontents{lol}{\protect\addvspace{10\p@}}% 
+    \orig@chapter
+}
+\makeatother
+
 \renewcommand{\listtheoremname}{Definitionen, Theoreme und Beweise}
 \cleardoublepage\phantomsection
 \renewcommand\thmtformatoptarg[1]{: \enquote{#1}}


### PR DESCRIPTION
There is a vertical spacing between chapters in the other directories, but not in the source code directory.

You can reproduce this error by creating another source code listing in any chapter (and for comparison, also a figure or table). With tables and lists of figures, a narrow 10pt gap appears between the chapters, but not with the list of source code.

<img width="244" height="77" alt="example-Quellcodeverzeichnis-vorher" src="https://github.com/user-attachments/assets/370975ac-0aa4-47e2-82c6-618b14b07aaf" />
(original) No vertical spacing between entries in source code directory.

<img width="244" height="99" alt="example-Tabellenverzeichnis" src="https://github.com/user-attachments/assets/e75af77d-26d6-4266-be95-5197a5ddbeba" />
(how it should be) Vertical spacing between entries in list of tables.

<img width="244" height="87" alt="example-Quellcodeverzeichnis-nachher" src="https://github.com/user-attachments/assets/88d975a6-c8a2-4bdd-84e6-a9174c3ccfdf" />
(new) With this fix, there is now also a vertical spacing in the source code directory.


